### PR TITLE
[Rails4] Update preferences lib

### DIFF
--- a/lib/preferences.rb
+++ b/lib/preferences.rb
@@ -605,7 +605,7 @@ module Preferences
             attributes.all? {|attribute, value| preference[attribute] == value} 
           end
         else
-          stored_preferences.find(:all, :conditions => attributes)
+          stored_preferences.where(**attributes)
         end
       end
   end

--- a/lib/preferences/preference_definition.rb
+++ b/lib/preferences/preference_definition.rb
@@ -43,10 +43,10 @@ module Preferences
       when :any
         value
       when :boolean
-        if value.class == 'String'
+        if value.class == String
           value == "1"
         else
-          default_value
+          value
         end
       else
         @column.type_cast(value)

--- a/lib/preferences/preference_definition.rb
+++ b/lib/preferences/preference_definition.rb
@@ -43,7 +43,7 @@ module Preferences
       when :any
         value
       when :boolean
-        if value.class == String
+        if value.is_a?(String)
           value == "1"
         else
           value

--- a/lib/preferences/preference_definition.rb
+++ b/lib/preferences/preference_definition.rb
@@ -39,7 +39,18 @@ module Preferences
     # This uses ActiveRecord's typecast functionality so the same rules for
     # typecasting a model's columns apply here.
     def type_cast(value)
-      @type == :any ? value : @column.type_cast(value)
+      case @type
+      when :any
+        value
+      when :boolean
+        if value.class == 'String'
+          value == "1"
+        else
+          default_value
+        end
+      else
+        @column.type_cast(value)
+      end
     end
     
     # Typecasts the value to true/false depending on the type of preference


### PR DESCRIPTION
Finalement j'ai réussi à faire un patch pas trop douloureux pour gérer le type cast

* utilise la méthode `where` plutôt que `find(:all)`
* Simplifie le type cast dans le cas ou la valeur est un boolean. ("1" ou true suivant que la préférence soit cachée, ou storée en bdd)